### PR TITLE
Fix typo in bug reporting instructions

### DIFF
--- a/units/en/unit0/1.mdx
+++ b/units/en/unit0/1.mdx
@@ -97,7 +97,7 @@ We would like to extend our gratitude to the following projects and communities:
 
 Contributions are **welcome** 🤗
 
-* If you _found a bug or error_, please [open an issue](https://github.com/huggingface/robotic-course/issues/new) and **describe the problem**.
+* If you _found a bug or error_, please [open an issue](https://github.com/huggingface/robotics-course/issues/new) and **describe the problem**.
 * If you _want to improve the course_, you can contribute to the robotics community through LeRobot development.
 * If you _want to add content or suggest improvements_, engage with the robotics community and share your ideas.
 


### PR DESCRIPTION
At the end of the page, the link to open issues for the course is wrong.