### PR TITLE
fix: resolve 422 error by aligning syllabus with actual file structure

### DIFF
--- a/units/en/unit0/1.mdx
+++ b/units/en/unit0/1.mdx
@@ -27,11 +27,9 @@ Here is the general syllabus for the robotics course. Each unit builds on the pr
 
 | # | Topic | Description | Released |
 | - | ----- | ----------- | -------- |
-| 0 | Course Introduction | Welcome, prerequisites, and course overview | ✅ |
-| 1 | Course Overview | Learning path and objectives | ✅ |
-| 2 | Introduction to Robotics | Why Robotics matters and LeRobot ecosystem | ✅ |
-| 3 | Classical Robotics | Traditional approaches and their limitations | ✅ |
-| 4 | Course Summary | Transition from classical to learning-based approaches | ✅ |
+| 0 | Welcome to the Robotics Course | Welcome, prerequisites, and course overview | ✅ |
+| 1 | Course Introduction | Introduction to Robot Learning and LeRobot ecosystem | ✅ |
+| 2 | Classical Robotics | Traditional approaches and their limitations | ✅ |
 | 5 | Reinforcement Learning | How robots learn through trial and error | Coming Soon |
 | 6 | Imitation Learning | Learning from demonstrations and behavioral cloning | Coming Soon |
 | 7 | Foundation Models | Large-scale models for general robotics | Coming Soon |


### PR DESCRIPTION
This PR tiny fixes #9 
- Remove non-existent Unit 4 from syllabus table
- Update unit titles to match _toctree.yml structure  
