### PR TITLE
Remove repeated line

### DIFF
--- a/units/en/unit1/1.mdx
+++ b/units/en/unit1/1.mdx
@@ -29,7 +29,6 @@ Today's robotics researchers are moving away from the traditional approach of wr
 - Extract useful information from many types of sensors (cameras, touch sensors, microphones) using data-driven methods.
 - Work effectively without needing perfect models of how the world behaves.
 - Take advantage of the growing number of open robotics datasets that anyone can access and learn from.
-- Work effectively without needing perfect models of how the world behaves.
 
 You can watch [this video](https://www.youtube.com/watch?v=VEs1QYEgOQo) to get a better sense of the paradigm shift currently undergoing in robotics.
 


### PR DESCRIPTION
Removed duplicate point about working effectively without perfect models.
The line "Work effectively without needing perfect models of how the world behaves." was present two times, so removed the second one.