### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ We would like to extend our gratitude to the following projects and communities:
 
 Contributions are **welcome** 🤗
 
-* If you _found a bug or error_, please [open an issue](https://github.com/huggingface/robotic-course/issues/new) and **describe the problem**.
+* If you _found a bug or error_, please [open an issue](https://github.com/huggingface/robotics-course/issues/new) and **describe the problem**.
 * If you _want to improve the course_, you can contribute to the robotics community through LeRobot development.
 * If you _want to add content or suggest improvements_, engage with the robotics community and share your ideas.


### PR DESCRIPTION
This PR fixes a small typo in the README.

Found at the end of the course introduction.

closes #19 
