### PR TITLE
fix: remove duplicate paragraph in Unit 1.4 (PyTorch DataLoader)

### DIFF
--- a/units/en/unit1/4.mdx
+++ b/units/en/unit1/4.mdx
@@ -138,7 +138,6 @@ sample = streaming_dataset[100]
 You can easily integrate regular and streaming datasets with torch data loaders. This makes integrating any LeRobotDataset with your own (`torch`) training loop rather convenient. Because we fetch all frames from the datasets as a tensor, wrapping iterating over a dataset with training is particularly straightforward.  
 
 ### PyTorch DataLoader
-You can easily integrate regular and streaming datasets with torch data loaders. This makes integrating any LeRobotDataset with your own (`torch`) training loop rather convenient. Because we fetch all frames from the datasets as a tensor, wrapping iterating over a dataset with training is particularly straightforward.
 ```python
 import torch
 from torch.utils.data import DataLoader


### PR DESCRIPTION
The intro paragraph under "## Training Integration" was duplicated verbatim under "### PyTorch DataLoader" in units/en/unit1/4.mdx. Removed the repeated line so the subsection flows directly into the code example. Addresses #29.